### PR TITLE
Systemd timer

### DIFF
--- a/haltoping.service
+++ b/haltoping.service
@@ -7,7 +7,6 @@ Type=simple
 ExecStart=/usr/local/bin/haltoping <ROUTER_IP>
 Restart=on-failure
 RestartSec=30s
-ExecStartPre=/bin/sleep 120
 
 [Install]
 WantedBy=multi-user.target

--- a/haltoping.timer
+++ b/haltoping.timer
@@ -1,0 +1,2 @@
+[Timer]
+OnBootSec=2min

--- a/haltoping.timer
+++ b/haltoping.timer
@@ -1,2 +1,9 @@
+[Unit]
+Description=Halt on ping - shutdown if ping fails
+After=network.target
+
 [Timer]
 OnBootSec=2min
+
+[Install]
+WantedBy=timers.target

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ fi
 
 SOURCE_DIR="$(dirname "$(readlink -f "$0")")"
 SCRIPT_DEST="/usr/local/bin/haltoping"
-SERVICE_DEST="/etc/systemd/system/haltoping.service"
+SERVICE_DEST="/etc/systemd/system/"
 
 if [[ $EUID -ne 0 ]]; then
    echo "This script must be run as root" 
@@ -18,11 +18,16 @@ fi
 
 cp "$SOURCE_DIR/haltoping" "$SCRIPT_DEST"
 chmod +x "$SCRIPT_DEST"
-cp "$SOURCE_DIR/haltoping.service" "$SERVICE_DEST"
-sed -i "s|ExecStart=.*|ExecStart=/usr/local/bin/haltoping ${ROUTER_IP}|g" "$SERVICE_DEST"
+
+echo "Installing haltoping service..."
+cp "$SOURCE_DIR/haltoping.timer" "${SERVICE_DEST}/"
+cp "$SOURCE_DIR/haltoping.service" "${SERVICE_DEST}/"
+sed -i "s|ExecStart=.*|ExecStart=/usr/local/bin/haltoping ${ROUTER_IP}|g" "${SERVICE_DEST}/haltoping.service"
 
 systemctl daemon-reload
-systemctl enable haltoping.service
-systemctl restart haltoping.service &
+systemctl disable haltoping.service
+systemctl enable haltoping.timer
+systemctl restart haltoping.service
+systemctl status haltoping.service
 
 echo "haltoping has been installed and started successfully."


### PR DESCRIPTION
Better handle start of the script on the boot.
Will:
- unblock current start depay
- prevent situation when server stuck in boot-loop - now you will have plenty of time to stop service on start in case of errors